### PR TITLE
fix: fixed details not cleared before navigate

### DIFF
--- a/nx-plugin/src/generators/angular/files/src/app/__remoteModuleFileName__-app.remote.module.ts.template
+++ b/nx-plugin/src/generators/angular/files/src/app/__remoteModuleFileName__-app.remote.module.ts.template
@@ -6,7 +6,6 @@ import { StoreRouterConnectingModule } from '@ngrx/router-store';
 import { StoreModule } from '@ngrx/store';
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 import {
-  MissingTranslationHandler,
   TranslateLoader,
   TranslateModule
 } from '@ngx-translate/core';
@@ -15,8 +14,7 @@ import {
   AppStateService,
   ConfigurationService,
   createTranslateLoader,
-  PortalCoreModule,
-  PortalMissingTranslationHandler
+  PortalCoreModule
 } from '@onecx/portal-integration-angular';
 import { routes } from './app-routing.module';
 import { commonImports } from './app.module';
@@ -47,11 +45,7 @@ effectProvidersForWorkaround.forEach(p => p.ɵprov.providedIn = null);
         provide: TranslateLoader,
         useFactory: createTranslateLoader,
         deps: [HttpClient, AppStateService],
-      },
-      missingTranslationHandler: {
-        provide: MissingTranslationHandler,
-        useClass: PortalMissingTranslationHandler,
-      },
+      }
     }),
     SharedModule,
     StoreModule.forRoot(reducers, { metaReducers }),

--- a/nx-plugin/src/generators/angular/files/src/app/app.component.spec.ts.template
+++ b/nx-plugin/src/generators/angular/files/src/app/app.component.spec.ts.template
@@ -12,7 +12,12 @@ describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations:[AppComponent],
-      imports: [RouterTestingModule, PortalCoreModule.forRoot('test'), HttpClientTestingModule],
+      imports: [
+        RouterTestingModule,
+        PortalCoreModule.forRoot('test'),
+        TranslateModule.forRoot(),
+        HttpClientTestingModule,
+      ],
       providers: [{ provide: AUTH_SERVICE, useClass: MockAuthModule }]
     }).compileComponents();
   });

--- a/nx-plugin/src/generators/angular/files/src/app/app.component.spec.ts.template
+++ b/nx-plugin/src/generators/angular/files/src/app/app.component.spec.ts.template
@@ -7,6 +7,7 @@ import {
     MockAuthModule
 } from '@onecx/portal-integration-angular';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TranslateTestingModule } from 'ngx-translate-testing';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
@@ -15,7 +16,7 @@ describe('AppComponent', () => {
       imports: [
         RouterTestingModule,
         PortalCoreModule.forRoot('test'),
-        TranslateModule.forRoot(),
+        TranslateTestingModule.withTranslations({}),
         HttpClientTestingModule,
       ],
       providers: [{ provide: AUTH_SERVICE, useClass: MockAuthModule }]

--- a/nx-plugin/src/generators/angular/files/src/app/app.module.ts.template
+++ b/nx-plugin/src/generators/angular/files/src/app/app.module.ts.template
@@ -9,12 +9,10 @@ import {
   ConfigurationService,
   createTranslateLoader,
   PortalCoreModule,
-  PortalMissingTranslationHandler,
   translateServiceInitializer,
   UserService
 } from '@onecx/portal-integration-angular';
 import {
-  MissingTranslationHandler,
   TranslateLoader,
   TranslateModule,
   TranslateService,
@@ -46,11 +44,7 @@ export const commonImports = [CommonModule];
         provide: TranslateLoader,
         useFactory: createTranslateLoader,
         deps: [HttpClient, AppStateService],
-      },
-      missingTranslationHandler: {
-        provide: MissingTranslationHandler,
-        useClass: PortalMissingTranslationHandler,
-      },
+      }
     }),
   ],
   providers: [

--- a/nx-plugin/src/generators/angular/generator.ts
+++ b/nx-plugin/src/generators/angular/generator.ts
@@ -60,7 +60,7 @@ export async function angularGenerator(
       propertyName: names(options.name).propertyName,
     }
   );
-  const oneCXLibVersion = '^4.10.2';
+  const oneCXLibVersion = '^4.33.2';
   addDependenciesToPackageJson(
     tree,
     {

--- a/nx-plugin/src/generators/details/files/ngrx/src/app/__featureFileName__/pages/__featureFileName__-details/__featureFileName__-details.actions.ts.template
+++ b/nx-plugin/src/generators/details/files/ngrx/src/app/__featureFileName__/pages/__featureFileName__-details/__featureFileName__-details.actions.ts.template
@@ -4,6 +4,9 @@ import { <%= dataObjectName %> } from '../../../shared/generated';
 export const <%= featureClassName %>DetailsActions = createActionGroup({
   source: '<%= featureClassName %>Details',
   events: {
+    'navigated to details': props<{
+      id: string | undefined;
+    }>(),
     '<%= featureFileName.replaceAll("-"," ") %> details received': props<{
       details: <%= dataObjectName %>;
     }>(),

--- a/nx-plugin/src/generators/details/files/ngrx/src/app/__featureFileName__/pages/__featureFileName__-details/__featureFileName__-details.actions.ts.template
+++ b/nx-plugin/src/generators/details/files/ngrx/src/app/__featureFileName__/pages/__featureFileName__-details/__featureFileName__-details.actions.ts.template
@@ -4,7 +4,7 @@ import { <%= dataObjectName %> } from '../../../shared/generated';
 export const <%= featureClassName %>DetailsActions = createActionGroup({
   source: '<%= featureClassName %>Details',
   events: {
-    'navigated to details': props<{
+    'navigated to details page': props<{
       id: string | undefined;
     }>(),
     '<%= featureFileName.replaceAll("-"," ") %> details received': props<{

--- a/nx-plugin/src/generators/details/files/ngrx/src/app/__featureFileName__/pages/__featureFileName__-details/__featureFileName__-details.effects.ts.template
+++ b/nx-plugin/src/generators/details/files/ngrx/src/app/__featureFileName__/pages/__featureFileName__-details/__featureFileName__-details.effects.ts.template
@@ -27,13 +27,13 @@ export class <%= featureClassName %>DetailsEffects {
     private messageService: PortalMessageService
   ) {}
 
-  navigatedToDetails$ = createEffect(() => {
+  navigatedToDetailsPage$ = createEffect(() => {
     return this.actions$.pipe(
       ofType(routerNavigatedAction),
       filterForNavigatedTo(this.router, <%= featureClassName %>DetailsComponent),
       concatLatestFrom(() => this.store.select(selectRouteParam('id'))),
       map(([, id]) => {
-        return <%= featureClassName %>DetailsActions.navigatedToDetails({
+        return <%= featureClassName %>DetailsActions.navigatedToDetailsPage({
           id,
         });
       })
@@ -42,7 +42,7 @@ export class <%= featureClassName %>DetailsEffects {
 
   load<%= featureClassName %>ById$ = createEffect(() => {
     return this.actions$.pipe(
-      ofType(<%= featureClassName %>DetailsActions.navigatedToDetails),
+      ofType(<%= featureClassName %>DetailsActions.navigatedToDetailsPage),
       switchMap(({ id }) =>
         this.<%= featurePropertyName %>Service.get<%= dataObjectName %>ById(id ?? '').pipe(
           map(({ result }) =>

--- a/nx-plugin/src/generators/details/files/ngrx/src/app/__featureFileName__/pages/__featureFileName__-details/__featureFileName__-details.effects.ts.template
+++ b/nx-plugin/src/generators/details/files/ngrx/src/app/__featureFileName__/pages/__featureFileName__-details/__featureFileName__-details.effects.ts.template
@@ -27,12 +27,23 @@ export class <%= featureClassName %>DetailsEffects {
     private messageService: PortalMessageService
   ) {}
 
-  load<%= featureClassName %>ById$ = createEffect(() => {
+  navigatedToDetails$ = createEffect(() => {
     return this.actions$.pipe(
       ofType(routerNavigatedAction),
       filterForNavigatedTo(this.router, <%= featureClassName %>DetailsComponent),
       concatLatestFrom(() => this.store.select(selectRouteParam('id'))),
-      switchMap(([, id]) =>
+      map(([, id]) => {
+        return <%= featureClassName %>DetailsActions.navigatedToDetails({
+          id,
+        });
+      })
+    );
+  });
+
+  load<%= featureClassName %>ById$ = createEffect(() => {
+    return this.actions$.pipe(
+      ofType(<%= featureClassName %>DetailsActions.navigatedToDetails),
+      switchMap(({ id }) =>
         this.<%= featurePropertyName %>Service.get<%= dataObjectName %>ById(id ?? '').pipe(
           map(({ result }) =>
             <%= featureClassName %>DetailsActions.<%= featurePropertyName %>DetailsReceived({

--- a/nx-plugin/src/generators/details/files/ngrx/src/app/__featureFileName__/pages/__featureFileName__-details/__featureFileName__-details.reducers.ts.template
+++ b/nx-plugin/src/generators/details/files/ngrx/src/app/__featureFileName__/pages/__featureFileName__-details/__featureFileName__-details.reducers.ts.template
@@ -21,5 +21,11 @@ export const <%= featurePropertyName %>DetailsReducer = createReducer(
       ...state,
       details: undefined,
     })
+  ),
+  on(
+    <%= featureClassName %>DetailsActions.navigatedToDetails,
+    (): <%= featureClassName %>DetailsState => ({
+      ...initialState,
+    })
   )
 );

--- a/nx-plugin/src/generators/details/files/ngrx/src/app/__featureFileName__/pages/__featureFileName__-details/__featureFileName__-details.reducers.ts.template
+++ b/nx-plugin/src/generators/details/files/ngrx/src/app/__featureFileName__/pages/__featureFileName__-details/__featureFileName__-details.reducers.ts.template
@@ -23,7 +23,7 @@ export const <%= featurePropertyName %>DetailsReducer = createReducer(
     })
   ),
   on(
-    <%= featureClassName %>DetailsActions.navigatedToDetails,
+    <%= featureClassName %>DetailsActions.navigatedToDetailsPage,
     (): <%= featureClassName %>DetailsState => ({
       ...initialState,
     })

--- a/nx-plugin/src/generators/feature/files/ngrx/src/app/__featureFileName__/__featureFileName__.module.ts.template
+++ b/nx-plugin/src/generators/feature/files/ngrx/src/app/__featureFileName__/__featureFileName__.module.ts.template
@@ -6,8 +6,7 @@ import {
   createTranslateLoader,
   PortalCoreModule,
   addInitializeModuleGuard,
-  AppStateService,
-  PortalMissingTranslationHandler
+  AppStateService
 } from '@onecx/portal-integration-angular';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CalendarModule } from 'primeng/calendar';
@@ -46,11 +45,7 @@ import { EffectsModule } from '@ngrx/effects';
         provide: TranslateLoader,
         useFactory: createTranslateLoader,
         deps: [HttpClient, AppStateService],
-      },
-      missingTranslationHandler: {
-        provide: MissingTranslationHandler,
-        useClass: PortalMissingTranslationHandler,
-      },
+      }
     }),
   ],
 })


### PR DESCRIPTION
This fixes the issue, that once navigated to a detail page, old content was shown until the new content was loaded.
By splitting the navigation into two actions, we can clear the state before triggering the loading.