### PR TITLE
feat: generate delete functionality

### DIFF
--- a/docs/modules/general/pages/getting_started/createDeleteDialog.adoc
+++ b/docs/modules/general/pages/getting_started/createDeleteDialog.adoc
@@ -1,11 +1,11 @@
-=== Create Create/Update Dialogs
-The fastest way to create a create and update dialogs in a feature module is to use the OneCX generator. Some projects have their own generator based on the OneCX generator. It should be clarified before starting if this is the case for the project the app is generated for. 
+=== Create Delete Dialog
+The fastest way to create a delete dialog in a feature module is to use the OneCX generator. Some projects have their own generator based on the OneCX generator. It should be clarified before starting if this is the case for the project the app is generated for. 
 
 ******
 To run the generator, execute the following command: 
 
 ----
-nx generate <namespaceOfTheGenerator>/nx-plugin:create-update <nameOfTheFeature> 
+nx generate <namespaceOfTheGenerator>/nx-plugin:delete <nameOfTheFeature> [--standalone]
 ----
 
 *Placeholder*: 
@@ -18,6 +18,11 @@ TIP: Next, the CLI will ask you whether you want to customize names for the gene
 When answering yes, the next few questions will ask you about names for the API.
 This can be useful if you want to adapt to a legacy API. 
 When modifying names, assure that you use the same custom names for all generated components of the feature (search, details, create-update, delete) for the data object name, and the api service name as these ones are shared.
+
+*Options*:
+
+* --standalone: if you want to develop an application that does not depend on onecx-services
+
 ******
 
 After running the generator, the following actions must be taken: 

--- a/docs/modules/general/pages/getting_started/createDetailsPage.adoc
+++ b/docs/modules/general/pages/getting_started/createDetailsPage.adoc
@@ -17,7 +17,7 @@ nx generate <namespaceOfTheGenerator>/nx-plugin:details <nameOfTheFeature>
 TIP: Next, the CLI will ask you whether you want to customize names for the generation.
 When answering yes, the next few questions will ask you about names for the API.
 This can be useful if you want to adapt to a legacy API.
-When modifying names, assure that you use the same custom names for all generated components of the feature (search, details, create-update) for the data object name, and the api service name as these ones are shared.
+When modifying names, assure that you use the same custom names for all generated components of the feature (search, details, create-update, delete) for the data object name, and the api service name as these ones are shared.
 ******
 
 After running the generator, the following actions must be taken: 

--- a/docs/modules/general/pages/getting_started/createSearchPage.adoc
+++ b/docs/modules/general/pages/getting_started/createSearchPage.adoc
@@ -16,7 +16,7 @@ nx generate <namespaceOfTheGenerator>/nx-plugin:search <nameOfTheFeature> [--sta
 TIP: Next, the CLI will ask you whether you want to customize names for the generation.
 When answering yes, the next few questions will ask you about names for the API.
 This can be useful if you want to adapt to a legacy API.
-When modifying names, assure that you use the same custom names for all generated components of the feature (search, details, create-update) for the data object name, and the api service name as these ones are shared.
+When modifying names, assure that you use the same custom names for all generated components of the feature (search, details, create-update, delete) for the data object name, and the api service name as these ones are shared.
 
 *Options*:
 

--- a/nx-plugin-e2e/src/nx-plugin.spec.ts
+++ b/nx-plugin-e2e/src/nx-plugin.spec.ts
@@ -185,6 +185,40 @@ describe('nx-plugin', () => {
     });
   });
 
+  it('should add a delete dialog', () => {
+    // Add all required parameters to this array with a value.
+    // As tests are non-interactive, not-added but required items will block the test
+    const requiredParameters = [
+      {
+        key: NON_INTERACTIVE_KEY,
+        value: true,
+      },
+    ];
+
+    const parameterString = requiredParameters
+      .map((o) => `--${o.key} ${o.value}`)
+      .join(' ');
+
+    execSync(
+      `nx generate @onecx/nx-plugin:delete ${featureName} ${parameterString} --verbose`,
+      {
+        cwd: projectDirectory,
+        stdio: 'inherit',
+        env: process.env,
+      }
+    );
+    execSync(`nx run build --skip-nx-cache`, {
+      cwd: projectDirectory,
+      stdio: 'inherit',
+      env: process.env,
+    });
+    execSync(`nx run test --skip-nx-cache --coverage`, {
+      cwd: projectDirectory,
+      stdio: 'inherit',
+      env: process.env,
+    });
+  });
+
   it('should add a custom naming feature', () => {
     execSync(
       `nx generate @onecx/nx-plugin:feature ${featureNameCustom} --verbose`,
@@ -303,7 +337,7 @@ describe('nx-plugin', () => {
     });
   });
 
-  it('should add a create-update dialog', () => {
+  it('should add a custom naming create-update dialog', () => {
     // Add all required parameters to this array with a value.
     // As tests are non-interactive, not-added but required items will block the test
     const requiredParameters = [
@@ -343,6 +377,48 @@ describe('nx-plugin', () => {
 
     execSync(
       `nx generate @onecx/nx-plugin:create-update ${featureNameCustom} ${parameterString} --verbose`,
+      {
+        cwd: projectDirectory,
+        stdio: 'inherit',
+        env: process.env,
+      }
+    );
+    execSync(`nx run build --skip-nx-cache`, {
+      cwd: projectDirectory,
+      stdio: 'inherit',
+      env: process.env,
+    });
+    execSync(`nx run test --skip-nx-cache --coverage`, {
+      cwd: projectDirectory,
+      stdio: 'inherit',
+      env: process.env,
+    });
+  });
+
+  it('should add a custom naming delete dialog', () => {
+    // Add all required parameters to this array with a value.
+    // As tests are non-interactive, not-added but required items will block the test
+    const requiredParameters = [
+      {
+        key: NON_INTERACTIVE_KEY,
+        value: true,
+      },
+      {
+        key: 'apiServiceName',
+        value: 'CustomService',
+      },
+      {
+        key: 'dataObjectName',
+        value: 'CustomDataObject',
+      },
+    ];
+
+    const parameterString = requiredParameters
+      .map((o) => `--${o.key} ${o.value}`)
+      .join(' ');
+
+    execSync(
+      `nx generate @onecx/nx-plugin:delete ${featureNameCustom} ${parameterString} --verbose`,
       {
         cwd: projectDirectory,
         stdio: 'inherit',

--- a/nx-plugin-e2e/src/nx-plugin.spec.ts
+++ b/nx-plugin-e2e/src/nx-plugin.spec.ts
@@ -219,7 +219,7 @@ describe('nx-plugin', () => {
     });
   });
 
-  it('should add a custom naming feature', () => {
+  it('should add a custom named feature', () => {
     execSync(
       `nx generate @onecx/nx-plugin:feature ${featureNameCustom} --verbose`,
       {
@@ -240,7 +240,7 @@ describe('nx-plugin', () => {
     });
   });
 
-  it('should add a custom naming search page', () => {
+  it('should add a custom named search page', () => {
     // Add all required parameters to this array with a value.
     // As tests are non-interactive, not-added but required items will block the test
     const requiredParameters = [
@@ -291,7 +291,7 @@ describe('nx-plugin', () => {
     });
   });
 
-  it('should add a custom naming details page', () => {
+  it('should add a custom named details page', () => {
     // Add all required parameters to this array with a value.
     // As tests are non-interactive, not-added but required items will block the test
     const requiredParameters = [
@@ -337,7 +337,7 @@ describe('nx-plugin', () => {
     });
   });
 
-  it('should add a custom naming create-update dialog', () => {
+  it('should add a custom named create-update dialog', () => {
     // Add all required parameters to this array with a value.
     // As tests are non-interactive, not-added but required items will block the test
     const requiredParameters = [
@@ -395,7 +395,7 @@ describe('nx-plugin', () => {
     });
   });
 
-  it('should add a custom naming delete dialog', () => {
+  it('should add a custom named delete dialog', () => {
     // Add all required parameters to this array with a value.
     // As tests are non-interactive, not-added but required items will block the test
     const requiredParameters = [

--- a/nx-plugin/generators.json
+++ b/nx-plugin/generators.json
@@ -40,6 +40,11 @@
       "factory": "./src/generators/standalone/ngrx/generator",
       "schema": "./src/generators/standalone/ngrx/schema.json",
       "description": "standalone ngrx generator"
+    },
+    "delete": {
+      "factory": "./src/generators/delete/generator",
+      "schema": "./src/generators/delete/schema.json",
+      "description": "delete generator"
     }
   }
 }

--- a/nx-plugin/src/generators/angular/generator.ts
+++ b/nx-plugin/src/generators/angular/generator.ts
@@ -87,7 +87,7 @@ export async function angularGenerator(
     tree.delete(`${directory}/scripts/load-permissions.sh`);
   }
 
-  const oneCXLibVersion = '^4.40.0';
+  const oneCXLibVersion = '^4.40.2';
   addDependenciesToPackageJson(
     tree,
     {

--- a/nx-plugin/src/generators/angular/generator.ts
+++ b/nx-plugin/src/generators/angular/generator.ts
@@ -87,7 +87,7 @@ export async function angularGenerator(
     tree.delete(`${directory}/scripts/load-permissions.sh`);
   }
 
-  const oneCXLibVersion = '^4.39.0';
+  const oneCXLibVersion = '^4.40.0';
   addDependenciesToPackageJson(
     tree,
     {

--- a/nx-plugin/src/generators/create-update/generator.ts
+++ b/nx-plugin/src/generators/create-update/generator.ts
@@ -299,28 +299,19 @@ function adaptSearchEffects(tree: Tree, options: CreateUpdateGeneratorSchema) {
     );
   }
 
-  if (!content.includes('refreshSearchAfterCreateUpdate$ =')) {
-    content = content.replace(
-      'searchByUrl$',
-      `
-          refreshSearchAfterCreateUpdate$ = createEffect(() => {
-            return this.actions$.pipe(
-              ofType(
-                ${className}SearchActions.create${className}Succeeded,
-                ${className}SearchActions.update${className}Succeeded
-              ),
-              concatLatestFrom(() => this.store.select(selectSearchCriteria)),
-              switchMap(([, searchCriteria]) => this.performSearch(searchCriteria))
-            );
-        });
-        
-        searchByUrl$`
-    );
-  }
-
   content = content.replace(
     'searchByUrl$',
     `
+    refreshSearchAfterCreateUpdate$ = createEffect(() => {
+      return this.actions$.pipe(
+        ofType(
+          ${className}SearchActions.create${className}Succeeded,
+          ${className}SearchActions.update${className}Succeeded
+        ),
+        concatLatestFrom(() => this.store.select(selectSearchCriteria)),
+        switchMap(([, searchCriteria]) => this.performSearch(searchCriteria))
+      );
+    });
     
     editButtonClicked$ = createEffect(() => {
     return this.actions$.pipe(

--- a/nx-plugin/src/generators/create-update/generator.ts
+++ b/nx-plugin/src/generators/create-update/generator.ts
@@ -340,7 +340,7 @@ function adaptSearchEffects(tree: Tree, options: CreateUpdateGeneratorSchema) {
         );
       }),
       switchMap((dialogResult) => {
-        if (dialogResult.button == 'secondary') {
+        if (!dialogResult || dialogResult.button == 'secondary') {
           return of(${className}SearchActions.update${className}Cancelled());
         }
         if (!dialogResult?.result) {
@@ -396,7 +396,7 @@ function adaptSearchEffects(tree: Tree, options: CreateUpdateGeneratorSchema) {
           );
         }),
         switchMap((dialogResult) => {
-          if (dialogResult.button == 'secondary') {
+          if (!dialogResult || dialogResult.button == 'secondary') {
             return of(${className}SearchActions.create${className}Cancelled());
           }
           if (!dialogResult?.result) {
@@ -527,12 +527,14 @@ function adaptFeatureModule(tree: Tree, options: CreateUpdateGeneratorSchema) {
     'declarations: [',
     `declarations: [${className}CreateUpdateComponent,`
   );
-  moduleContent = moduleContent.replace(
-    'declarations:',
-    `
+  if (!moduleContent.includes('providePortalDialogService()')) {
+    moduleContent = moduleContent.replace(
+      'declarations:',
+      `
     providers: [providePortalDialogService()],
     declarations:`
-  );
+    );
+  }
   moduleContent = moduleContent.replace(
     `from '@ngrx/effects';`,
     `from '@ngrx/effects';  

--- a/nx-plugin/src/generators/create-update/generator.ts
+++ b/nx-plugin/src/generators/create-update/generator.ts
@@ -298,11 +298,11 @@ function adaptSearchEffects(tree: Tree, options: CreateUpdateGeneratorSchema) {
     );
   }
 
-  if (!content.includes('refreshSearch$ =')) {
+  if (!content.includes('refreshSearchAfterCreateUpdate$ =')) {
     content = content.replace(
       'searchByUrl$',
       `
-          refreshSearch$ = createEffect(() => {
+          refreshSearchAfterCreateUpdate$ = createEffect(() => {
             return this.actions$.pipe(
               ofType(
                 ${className}SearchActions.create${className}Succeeded,

--- a/nx-plugin/src/generators/create-update/generator.ts
+++ b/nx-plugin/src/generators/create-update/generator.ts
@@ -288,7 +288,8 @@ function adaptSearchEffects(tree: Tree, options: CreateUpdateGeneratorSchema) {
       ${options.createRequestName},
       ${options.updateRequestName},
     } from 'src/app/shared/generated';` +
-    `import { ${className}CreateUpdateComponent } from './dialogs/${options.featureName}-create-update/${options.featureName}-create-update.component';`;
+    `import { ${className}CreateUpdateComponent } from './dialogs/${options.featureName}-create-update/${options.featureName}-create-update.component';` +
+    content;
 
   if (!content.includes('private portalDialogService: PortalDialogService')) {
     content = content.replace(

--- a/nx-plugin/src/generators/delete/generator.ts
+++ b/nx-plugin/src/generators/delete/generator.ts
@@ -115,7 +115,6 @@ function addDeleteEventsToSearch(tree: Tree, options: DeleteGeneratorSchema) {
 
 function adaptFeatureModule(tree: Tree, options: DeleteGeneratorSchema) {
   const fileName = names(options.featureName).fileName;
-  const className = names(options.featureName).className;
   const moduleFilePath = joinPathFragments(
     'src/app',
     fileName,

--- a/nx-plugin/src/generators/delete/generator.ts
+++ b/nx-plugin/src/generators/delete/generator.ts
@@ -71,7 +71,7 @@ export async function createUpdateGenerator(
     throw new Error('Currently only NgRx projects are supported.');
   }
 
-  addCreateUpdateEventsToSearch(tree, options);
+  addDeleteEventsToSearch(tree, options);
 
   addTranslations(tree, options);
 
@@ -103,19 +103,15 @@ export async function createUpdateGenerator(
   };
 }
 
-function addCreateUpdateEventsToSearch(
+function addDeleteEventsToSearch(
   tree: Tree,
   options: DeleteGeneratorSchema
 ) {
-  const fileName = names(options.featureName).fileName;
-  const htmlDetailsFilePath = `src/app/${fileName}/pages/${fileName}-search/dialogs/${fileName}-create-update/${fileName}-create-update.component.html`;
-  if (tree.exists(htmlDetailsFilePath)) {
-    adaptSearchActions(tree, options);
-    adaptSearchEffects(tree, options);
-    adaptSearchComponent(tree, options);
-    adaptSearchHTML(tree, options);
-    adaptSearchTests(tree, options);
-  }
+  adaptSearchActions(tree, options);
+  adaptSearchEffects(tree, options);
+  adaptSearchComponent(tree, options);
+  adaptSearchHTML(tree, options);
+  adaptSearchTests(tree, options);
 }
 
 function adaptSearchHTML(tree: Tree, options: DeleteGeneratorSchema) {
@@ -189,7 +185,7 @@ function adaptSearchEffects(tree: Tree, options: DeleteGeneratorSchema) {
 
   let content = tree.read(filePath, 'utf8');
   content =
-    `import { PortalDialogService } from '@onecx/portal-integration-angular';` +
+    `import { PortalDialogService, DialogState } from '@onecx/portal-integration-angular';` +
     `import { mergeMap } from 'rxjs';` +
     `import {
       ${options.dataObjectName},
@@ -205,15 +201,14 @@ function adaptSearchEffects(tree: Tree, options: DeleteGeneratorSchema) {
     );
   }
 
-  if (!content.includes('refreshSearch$ =')) {
+  if (!content.includes('refreshSearchAfterDelete$ =')) {
     content = content.replace(
       'searchByUrl$',
       `
-        refreshSearch$ = createEffect(() => {
+        refreshSearchAfterDelete$ = createEffect(() => {
           return this.actions$.pipe(
             ofType(
-              ${className}SearchActions.create${className}Succeeded,
-              ${className}SearchActions.update${className}Succeeded
+              ${className}SearchActions.delete${className}Succeeded,
             ),
             concatLatestFrom(() => this.store.select(selectSearchCriteria)),
             switchMap(([, searchCriteria]) => this.performSearch(searchCriteria))

--- a/nx-plugin/src/generators/delete/generator.ts
+++ b/nx-plugin/src/generators/delete/generator.ts
@@ -132,7 +132,6 @@ function adaptSearchHTML(tree: Tree, options: DeleteGeneratorSchema) {
 function adaptSearchComponent(tree: Tree, options: DeleteGeneratorSchema) {
   const fileName = names(options.featureName).fileName;
   const className = names(options.featureName).className;
-  const constantName = names(options.featureName).constantName;
   const filePath = `src/app/${fileName}/pages/${fileName}-search/${fileName}-search.component.ts`;
 
   let content = tree.read(filePath, 'utf8');

--- a/nx-plugin/src/generators/delete/generator.ts
+++ b/nx-plugin/src/generators/delete/generator.ts
@@ -103,10 +103,7 @@ export async function createUpdateGenerator(
   };
 }
 
-function addDeleteEventsToSearch(
-  tree: Tree,
-  options: DeleteGeneratorSchema
-) {
+function addDeleteEventsToSearch(tree: Tree, options: DeleteGeneratorSchema) {
   adaptSearchActions(tree, options);
   adaptSearchEffects(tree, options);
   adaptSearchComponent(tree, options);
@@ -200,27 +197,19 @@ function adaptSearchEffects(tree: Tree, options: DeleteGeneratorSchema) {
     );
   }
 
-  if (!content.includes('refreshSearchAfterDelete$ =')) {
-    content = content.replace(
-      'searchByUrl$',
-      `
-        refreshSearchAfterDelete$ = createEffect(() => {
-          return this.actions$.pipe(
-            ofType(
-              ${className}SearchActions.delete${className}Succeeded,
-            ),
-            concatLatestFrom(() => this.store.select(selectSearchCriteria)),
-            switchMap(([, searchCriteria]) => this.performSearch(searchCriteria))
-          );
-      });
-      
-      searchByUrl$`
-    );
-  }
-
   content = content.replace(
     'searchByUrl$',
     `
+    refreshSearchAfterDelete$ = createEffect(() => {
+      return this.actions$.pipe(
+        ofType(
+          ${className}SearchActions.delete${className}Succeeded,
+        ),
+        concatLatestFrom(() => this.store.select(selectSearchCriteria)),
+        switchMap(([, searchCriteria]) => this.performSearch(searchCriteria))
+      );
+    });
+    
     deleteButtonClicked$ = createEffect(() => {
     return this.actions$.pipe(
       ofType(${className}SearchActions.delete${className}ButtonClicked),

--- a/nx-plugin/src/generators/delete/generator.ts
+++ b/nx-plugin/src/generators/delete/generator.ts
@@ -49,6 +49,12 @@ const PARAMETERS: GeneratorParameter<DeleteGeneratorSchema>[] = [
     showInSummary: true,
     showRules: [{ showIf: (values) => values.customizeNamingForAPI }],
   },
+  {
+    key: 'standalone',
+    type: 'boolean',
+    required: 'never',
+    default: false,
+  },
 ];
 
 export async function createUpdateGenerator(
@@ -148,7 +154,7 @@ function adaptSearchHTML(tree: Tree, options: DeleteGeneratorSchema) {
     '<ocx-interactive-data-view',
     `<ocx-interactive-data-view 
       (deleteItem)="delete($event)"
-      deletePermission="${constantName}#DELETE"`
+      ${options.standalone ? '' : `deletePermission="${constantName}#DELETE"`}`
   );
   tree.write(htmlSearchFilePath, htmlContent);
 }

--- a/nx-plugin/src/generators/delete/generator.ts
+++ b/nx-plugin/src/generators/delete/generator.ts
@@ -1,0 +1,445 @@
+import {
+  formatFiles,
+  GeneratorCallback,
+  installPackagesTask,
+  joinPathFragments,
+  names,
+  readJson,
+  Tree,
+  updateJson,
+} from '@nx/devkit';
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as ora from 'ora';
+import { deepMerge } from '../shared/deepMerge';
+
+import { OpenAPIUtil } from '../shared/openapi/openapi.utils';
+import processParams, { GeneratorParameter } from '../shared/parameters.utils';
+import { renderJsonFile } from '../shared/renderJsonFile';
+import { DeleteGeneratorSchema } from './schema';
+import path = require('path');
+
+const PARAMETERS: GeneratorParameter<DeleteGeneratorSchema>[] = [
+  {
+    key: 'customizeNamingForAPI',
+    type: 'boolean',
+    required: 'interactive',
+    default: false,
+    prompt: 'Do you want to customize the names for the generated API?',
+  },
+  {
+    key: 'apiServiceName',
+    type: 'text',
+    required: 'interactive',
+    default: (values) => {
+      return `${names(values.featureName).className}BffService`;
+    },
+    prompt: 'Provide a name for your API service (e.g., BookBffService): ',
+    showInSummary: true,
+    showRules: [{ showIf: (values) => values.customizeNamingForAPI }],
+  },
+  {
+    key: 'dataObjectName',
+    type: 'text',
+    required: 'interactive',
+    default: (values) => {
+      return `${names(values.featureName).className}`;
+    },
+    prompt: 'Provide a name for your Data Object (e.g., Book): ',
+    showInSummary: true,
+    showRules: [{ showIf: (values) => values.customizeNamingForAPI }],
+  },
+];
+
+export async function createUpdateGenerator(
+  tree: Tree,
+  options: DeleteGeneratorSchema
+): Promise<GeneratorCallback> {
+  const parameters = await processParams<DeleteGeneratorSchema>(
+    PARAMETERS,
+    options
+  );
+  Object.assign(options, parameters);
+
+  const spinner = ora(`Adding delete to ${options.featureName}`).start();
+
+  const isNgRx = !!Object.keys(
+    readJson(tree, 'package.json').dependencies
+  ).find((k) => k.includes('@ngrx/'));
+  if (!isNgRx) {
+    spinner.fail('Currently only NgRx projects are supported.');
+    throw new Error('Currently only NgRx projects are supported.');
+  }
+
+  addCreateUpdateEventsToSearch(tree, options);
+
+  addTranslations(tree, options);
+
+  addFunctionToOpenApi(tree, options);
+
+  await formatFiles(tree);
+
+  spinner.succeed();
+
+  return () => {
+    installPackagesTask(tree);
+    execSync('npm run apigen', {
+      cwd: tree.root,
+      stdio: 'inherit',
+    });
+    const files = tree
+      .listChanges()
+      .map((c) => c.path)
+      .filter((p) => p.endsWith('.ts'))
+      .join(' ');
+    execSync('npx organize-imports-cli ' + files, {
+      cwd: tree.root,
+      stdio: 'inherit',
+    });
+    execSync('npx prettier --write ' + files, {
+      cwd: tree.root,
+      stdio: 'inherit',
+    });
+  };
+}
+
+function addCreateUpdateEventsToSearch(
+  tree: Tree,
+  options: DeleteGeneratorSchema
+) {
+  const fileName = names(options.featureName).fileName;
+  const htmlDetailsFilePath = `src/app/${fileName}/pages/${fileName}-search/dialogs/${fileName}-create-update/${fileName}-create-update.component.html`;
+  if (tree.exists(htmlDetailsFilePath)) {
+    adaptSearchActions(tree, options);
+    adaptSearchEffects(tree, options);
+    adaptSearchComponent(tree, options);
+    adaptSearchHTML(tree, options);
+    adaptSearchTests(tree, options);
+  }
+}
+
+function adaptSearchHTML(tree: Tree, options: DeleteGeneratorSchema) {
+  const fileName = names(options.featureName).fileName;
+  const constantName = names(options.featureName).constantName;
+  const htmlSearchFilePath = `src/app/${fileName}/pages/${fileName}-search/${fileName}-search.component.html`;
+
+  let htmlContent = tree.read(htmlSearchFilePath, 'utf8');
+  htmlContent = htmlContent.replace(
+    '<ocx-interactive-data-view',
+    `<ocx-interactive-data-view 
+      (deleteItem)="delete($event)"
+      deletePermission="${constantName}#DELETE"`
+  );
+  tree.write(htmlSearchFilePath, htmlContent);
+}
+
+function adaptSearchComponent(tree: Tree, options: DeleteGeneratorSchema) {
+  const fileName = names(options.featureName).fileName;
+  const className = names(options.featureName).className;
+  const constantName = names(options.featureName).constantName;
+  const filePath = `src/app/${fileName}/pages/${fileName}-search/${fileName}-search.component.ts`;
+
+  let content = tree.read(filePath, 'utf8');
+  content = content.replace(
+    `} from '@onecx/portal-integration-angular';`,
+    `RowListGridData
+    } from '@onecx/portal-integration-angular';`
+  );
+
+  content = content.replace(
+    'resetSearch',
+    `  
+    delete({ id }: RowListGridData) {
+      this.store.dispatch(${className}SearchActions.delete${className}ButtonClicked({ id }));
+    }
+
+    resetSearch`
+  );
+  tree.write(filePath, content);
+}
+
+function adaptSearchActions(tree: Tree, options: DeleteGeneratorSchema) {
+  const fileName = names(options.featureName).fileName;
+  const filePath = `src/app/${fileName}/pages/${fileName}-search/${fileName}-search.actions.ts`;
+  const actionName = names(options.featureName).fileName.replaceAll('-', ' ');
+
+  let content = tree.read(filePath, 'utf8');
+  content = content.replace(
+    'events: {',
+    `events: {      
+      'Delete ${actionName} button clicked': props<{
+        id: number | string;
+      }>(),
+      'Delete ${actionName} cancelled': emptyProps(),
+      'Delete ${actionName} succeeded': emptyProps(),      
+      'Delete ${actionName} failed': props<{
+        error: string | null;
+      }>(),
+    `
+  );
+  tree.write(filePath, content);
+}
+
+function adaptSearchEffects(tree: Tree, options: DeleteGeneratorSchema) {
+  const fileName = names(options.featureName).fileName;
+  const className = names(options.featureName).className;
+  const propertyName = names(options.featureName).propertyName;
+  const constantName = names(options.featureName).constantName;
+  const filePath = `src/app/${fileName}/pages/${fileName}-search/${fileName}-search.effects.ts`;
+
+  let content = tree.read(filePath, 'utf8');
+  content =
+    `import { PortalDialogService } from '@onecx/portal-integration-angular';` +
+    `import { mergeMap } from 'rxjs';` +
+    `import {
+      ${options.dataObjectName},
+    } from 'src/app/shared/generated';` +
+    `import { PrimeIcons } from 'primeng/api';` +
+    content;
+
+  if (!content.includes('private portalDialogService: PortalDialogService')) {
+    content = content.replace(
+      'constructor(',
+      `constructor(
+      private portalDialogService: PortalDialogService,`
+    );
+  }
+
+  if (!content.includes('refreshSearch$ =')) {
+    content = content.replace(
+      'searchByUrl$',
+      `
+        refreshSearch$ = createEffect(() => {
+          return this.actions$.pipe(
+            ofType(
+              ${className}SearchActions.create${className}Succeeded,
+              ${className}SearchActions.update${className}Succeeded
+            ),
+            concatLatestFrom(() => this.store.select(selectSearchCriteria)),
+            switchMap(([, searchCriteria]) => this.performSearch(searchCriteria))
+          );
+      });
+      
+      searchByUrl$`
+    );
+  }
+
+  content = content.replace(
+    'searchByUrl$',
+    `
+    deleteButtonClicked$ = createEffect(() => {
+    return this.actions$.pipe(
+      ofType(${className}SearchActions.delete${className}ButtonClicked),
+      concatLatestFrom(() =>
+        this.store.select(${propertyName}SearchSelectors.selectResults)
+      ),
+      map(([action, results]) => {
+        return results.find((item) => item.id == action.id);
+      }),
+      mergeMap((itemToDelete) => {
+        return this.portalDialogService.openDialog<unknown>(
+          '${constantName}_DELETE.HEADER',
+          '${constantName}_DELETE.MESSAGE',
+          {
+            key: '${constantName}_DELETE.CONFIRM',
+            icon: PrimeIcons.CHECK,
+          },
+          {
+            key: '${constantName}_DELETE.CANCEL',
+            icon: PrimeIcons.TIMES,
+          }
+        )
+        .pipe(
+          map(
+            (state): [DialogState<unknown>, ${options.dataObjectName} | undefined] => {
+              return [state, itemToDelete];
+            }
+          )
+        );
+      }),
+      switchMap(([dialogResult, itemToDelete]) => {
+        if (dialogResult.button == 'secondary') {
+          return of(${className}SearchActions.delete${className}Cancelled());
+        }
+        if (!itemToDelete) {
+          throw new Error('Item to delete not found!');
+        }
+        
+        return this.${propertyName}Service
+          .delete${options.dataObjectName}(itemToDelete.id)
+          .pipe(
+            map(() => {
+              this.messageService.success({
+                summaryKey: '${constantName}_DELETE.SUCCESS',
+              });
+              return ${className}SearchActions.delete${className}Succeeded();
+            })
+          );
+      }),
+      catchError((error) => {
+        this.messageService.error({
+          summaryKey: '${constantName}_DELETE.ERROR',
+        });
+        return of(
+          ${className}SearchActions.delete${className}Failed({
+            error,
+          })
+        );
+      })
+    );
+  });
+
+    searchByUrl$`
+  );
+  tree.write(filePath, content);
+}
+
+function adaptSearchTests(tree: Tree, options: DeleteGeneratorSchema) {
+  const fileName = names(options.featureName).fileName;
+  const className = names(options.featureName).className;
+  const propertyName = names(options.featureName).propertyName;
+  const filePath = `src/app/${fileName}/pages/${fileName}-search/${fileName}-search.component.spec.ts`;
+
+  let htmlContent = tree.read(filePath, 'utf8');
+
+  htmlContent =
+    `import { PrimeIcons } from 'primeng/api';` +
+    htmlContent.replace(
+      "it('should dispatch export csv data on export action click'",
+      `
+    it('should dispatch delete${className}ButtonClicked action on item delete click', async () => {
+      jest.spyOn(store, 'dispatch');
+  
+      store.overrideSelector(select${className}SearchViewModel, {
+        ...base${className}SearchViewModel,
+        results: [
+          {
+            id: '1',
+            imagePath: '',
+            column_1: 'val_1',
+          },
+        ],
+        columns: [
+          {
+            columnType: ColumnType.STRING,
+            nameKey: 'COLUMN_KEY',
+            id: 'column_1',
+          },
+        ],
+      });
+      store.refreshState();
+  
+      const interactiveDataView =
+        await ${propertyName}Search.getSearchResults();
+      const dataView = await interactiveDataView.getDataView();
+      const dataTable = await dataView.getDataTable();
+      const rowActionButtons = await dataTable.getActionButtons();
+  
+      expect(rowActionButtons.length).toBeGreaterThan(0);
+      let deleteButton;
+      for (const actionButton of rowActionButtons) {
+        const icon = await actionButton.getAttribute('ng-reflect-icon');
+        expect(icon).toBeTruthy();;
+        if (icon == 'pi pi-trash') {
+          deleteButton = actionButton;
+        }
+      }
+      expect(deleteButton).toBeTruthy();
+      deleteButton?.click();
+  
+      expect(store.dispatch).toHaveBeenCalledWith(
+        ${className}SearchActions.delete${className}ButtonClicked({ id: '1' })
+      );
+    });
+
+    it('should export csv data on export action click'`
+    );
+  tree.write(filePath, htmlContent);
+}
+
+function addTranslations(tree: Tree, options: DeleteGeneratorSchema) {
+  const folderPath = 'src/assets/i18n/';
+  const masterJsonPath = path.resolve(
+    __dirname,
+    './input-files/i18n/master.json.template'
+  );
+
+  const masterJsonContent = renderJsonFile(masterJsonPath, {
+    ...options,
+    featureConstantName: names(options.featureName).constantName,
+    featureClassName: names(options.featureName).className,
+  });
+
+  tree.children(folderPath).forEach((file) => {
+    updateJson(tree, joinPathFragments(folderPath, file), (json) => {
+      const jsonPath = joinPathFragments(
+        path.resolve(__dirname, './input-files/i18n/'),
+        file + '.template'
+      );
+      let jsonContent = {};
+      if (fs.existsSync(jsonPath)) {
+        jsonContent = renderJsonFile(jsonPath, {
+          ...options,
+          featureConstantName: names(options.featureName).constantName,
+          featureClassName: names(options.featureName).className,
+        });
+      }
+
+      json = deepMerge(masterJsonContent, jsonContent, json);
+
+      return json;
+    });
+  });
+}
+
+function addFunctionToOpenApi(tree: Tree, options: DeleteGeneratorSchema) {
+  const openApiFolderPath = 'src/assets/swagger';
+  const openApiFiles = tree.children(openApiFolderPath);
+  const bffOpenApiPath = openApiFiles.find((f) => f.endsWith('-bff.yaml'));
+  const bffOpenApiContent = tree.read(
+    joinPathFragments(openApiFolderPath, bffOpenApiPath),
+    'utf8'
+  );
+
+  const dataObjectName = options.dataObjectName;
+  const propertyName = names(options.featureName).propertyName;
+  const apiServiceName = options.apiServiceName;
+
+  const apiUtil = new OpenAPIUtil(bffOpenApiContent);
+
+  apiUtil.paths().set(
+    `/${propertyName}/{id}`,
+    {
+      delete: {
+        tags: [apiServiceName],
+        operationId: `delete${dataObjectName}`,
+        description: `Delete ${dataObjectName} by id`,
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+        responses: {
+          '204': {
+            description: `${dataObjectName} deleted`,
+          },
+        },
+      },
+    },
+    {
+      existStrategy: 'extend',
+    }
+  );
+
+  tree.write(
+    joinPathFragments(openApiFolderPath, bffOpenApiPath),
+    apiUtil.finalize()
+  );
+}
+
+export default createUpdateGenerator;

--- a/nx-plugin/src/generators/delete/input-files/i18n/de.json.template
+++ b/nx-plugin/src/generators/delete/input-files/i18n/de.json.template
@@ -1,0 +1,10 @@
+{
+  "<%= featureConstantName %>_DELETE": {
+    "HEADER": "ACTION: Add Translation",
+    "MESSAGE": "ACTION: Add Translation",
+    "CONFIRM": "ACTION: Add Translation",
+    "CANCEL": "ACTION: Add Translation",
+    "SUCCESS": "ACTION: Add Translation",
+    "ERROR": "ACTION: Add Translation"
+  }
+}

--- a/nx-plugin/src/generators/delete/input-files/i18n/de.json.template
+++ b/nx-plugin/src/generators/delete/input-files/i18n/de.json.template
@@ -1,10 +1,10 @@
 {
   "<%= featureConstantName %>_DELETE": {
-    "HEADER": "ACTION: Add Translation",
-    "MESSAGE": "ACTION: Add Translation",
-    "CONFIRM": "ACTION: Add Translation",
-    "CANCEL": "ACTION: Add Translation",
-    "SUCCESS": "ACTION: Add Translation",
-    "ERROR": "ACTION: Add Translation"
+    "HEADER": "<%= featureClassName %> löschen",
+    "MESSAGE": "Bitte bestätigen, dass diese <%= featureClassName %> gelöscht werden soll.",
+    "CONFIRM": "Bestätigen",
+    "CANCEL": "Abbrechen",
+    "SUCCESS": "<%= featureClassName %> erfolgreich gelöscht",
+    "ERROR": "Konnte <%= featureClassName %> nicht löschen"
   }
 }

--- a/nx-plugin/src/generators/delete/input-files/i18n/en.json.template
+++ b/nx-plugin/src/generators/delete/input-files/i18n/en.json.template
@@ -1,0 +1,10 @@
+{
+  "<%= featureConstantName %>_DELETE": {
+    "HEADER": "ACTION: Add Translation",
+    "MESSAGE": "ACTION: Add Translation",
+    "CONFIRM": "ACTION: Add Translation",
+    "CANCEL": "ACTION: Add Translation",
+    "SUCCESS": "ACTION: Add Translation",
+    "ERROR": "ACTION: Add Translation"
+  }
+}

--- a/nx-plugin/src/generators/delete/input-files/i18n/en.json.template
+++ b/nx-plugin/src/generators/delete/input-files/i18n/en.json.template
@@ -1,6 +1,6 @@
 {
   "<%= featureConstantName %>_DELETE": {
-    "HEADER": "Delete <%= featureConstantName %>",
+    "HEADER": "Delete <%= featureClassName %>",
     "MESSAGE": "Please confirm that you want to delete this <%= featureClassName %>.",
     "CONFIRM": "Confirm",
     "CANCEL": "Cancel",

--- a/nx-plugin/src/generators/delete/input-files/i18n/en.json.template
+++ b/nx-plugin/src/generators/delete/input-files/i18n/en.json.template
@@ -1,10 +1,10 @@
 {
   "<%= featureConstantName %>_DELETE": {
-    "HEADER": "ACTION: Add Translation",
-    "MESSAGE": "ACTION: Add Translation",
-    "CONFIRM": "ACTION: Add Translation",
-    "CANCEL": "ACTION: Add Translation",
-    "SUCCESS": "ACTION: Add Translation",
-    "ERROR": "ACTION: Add Translation"
+    "HEADER": "Delete <%= featureConstantName %>",
+    "MESSAGE": "Please confirm that you want to delete this <%= featureClassName %>.",
+    "CONFIRM": "Confirm",
+    "CANCEL": "Cancel",
+    "SUCCESS": "<%= featureClassName %> deleted successfully",
+    "ERROR": "Could not delete <%= featureClassName %>"
   }
 }

--- a/nx-plugin/src/generators/delete/input-files/i18n/master.json.template
+++ b/nx-plugin/src/generators/delete/input-files/i18n/master.json.template
@@ -1,0 +1,10 @@
+{
+  "<%= featureConstantName %>_DELETE": {
+    "HEADER": "ACTION: Add Translation",
+    "MESSAGE": "ACTION: Add Translation",
+    "CONFIRM": "ACTION: Add Translation",
+    "CANCEL": "ACTION: Add Translation",
+    "SUCCESS": "ACTION: Add Translation",
+    "ERROR": "ACTION: Add Translation"
+  }
+}

--- a/nx-plugin/src/generators/delete/schema.d.ts
+++ b/nx-plugin/src/generators/delete/schema.d.ts
@@ -3,4 +3,5 @@ export interface DeleteGeneratorSchema {
   customizeNamingForAPI: boolean;
   apiServiceName: string;
   dataObjectName: string;
+  standalone?: boolean;
 }

--- a/nx-plugin/src/generators/delete/schema.d.ts
+++ b/nx-plugin/src/generators/delete/schema.d.ts
@@ -1,0 +1,6 @@
+export interface DeleteGeneratorSchema {
+  featureName: string;
+  customizeNamingForAPI: boolean;
+  apiServiceName: string;
+  dataObjectName: string;
+}

--- a/nx-plugin/src/generators/delete/schema.json
+++ b/nx-plugin/src/generators/delete/schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "CreateUpdate",
+  "title": "",
+  "type": "object",
+  "properties": {
+    "featureName": {
+      "type": "string",
+      "description": "",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "To which feature would you like add the delete?"
+    }
+  },
+  "required": ["featureName"]
+}

--- a/nx-plugin/src/generators/delete/schema.json
+++ b/nx-plugin/src/generators/delete/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "$id": "CreateUpdate",
+  "$id": "Delete",
   "title": "",
   "type": "object",
   "properties": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.0",
   "license": "MIT",
   "scripts": {
-    "build": "nx run nx-plugin:build",
+    "build": "nx run nx-plugin:build && nx run create-workspace:build",
     "test": "nx run nx-plugin-e2e:e2e"
   },
   "private": true,


### PR DESCRIPTION
This PR adds a generator which can generate the functionality to confirm-and-delete entries of the search results.

In addition some fixes were applied to the create-update generator which would lead to duplicated generated code when delete / create-update are used together and in different order.

Lastly the build script was modified to build both plugins.