### PR TITLE
fix: fixed wrong name used when adapting project configuration

### DIFF
--- a/nx-plugin/src/generators/angular/generator.ts
+++ b/nx-plugin/src/generators/angular/generator.ts
@@ -197,7 +197,7 @@ function adaptProjectConfiguration(
   tree: Tree,
   options: AngularGeneratorSchema
 ) {
-  const config = readProjectConfiguration(tree, names(options.name).fileName);
+  const config = readProjectConfiguration(tree, options.name);
   config.targets['serve'].executor = '@nx/angular:dev-server';
   config.targets['serve'].options = {
     ...(config.targets['serve'].options ?? {}),


### PR DESCRIPTION
When using a camelCase name, the fileName used was different from the actual name.