### PR TITLE
fix: will use primeng instance of shell if primeng version of shell i…

### DIFF
--- a/nx-plugin/src/generators/angular/generator.ts
+++ b/nx-plugin/src/generators/angular/generator.ts
@@ -81,7 +81,7 @@ export async function angularGenerator(
     {
       primeflex: '^3.3.1',
       primeicons: '^7.0.0',
-      primeng: '17.18.8',
+      primeng: '^17.18.8',
       '@onecx/accelerator': oneCXLibVersion,
       '@onecx/angular-accelerator': oneCXLibVersion,
       '@onecx/angular-auth': oneCXLibVersion,


### PR DESCRIPTION
…s newer
This is done to prevent that the app is using its own primeng instance instead of using the shared one, which can cause issues. 