### PR TITLE
Fix: expose to main in webpack config

### DIFF
--- a/nx-plugin/src/generators/angular/files/webpack.config.js.template
+++ b/nx-plugin/src/generators/angular/files/webpack.config.js.template
@@ -8,7 +8,7 @@ const config = withModuleFederationPlugin({
   filename: 'remoteEntry.js',
   exposes: {
     './<%= remoteModuleName %>Module':
-      './src/bootstrap.ts',
+      './src/main.ts',
   },
   shared: share({
     '@angular/core': {


### PR DESCRIPTION
When migration to Angular 18, the config has been adjusted but does not expose to main.ts. Through that errors with the microservices are not displayed correctly and it just fails. Exposing to main solves the issue and this is also done in other OneCX projects, e.g. https://github.com/onecx/onecx-tenant-ui/blob/main/webpack.config.js.