### PR TITLE
fix: correct the addInitializeModuleGuard Import

### DIFF
--- a/nx-plugin/src/generators/angular/files/src/app/app-routing.module.ts.template
+++ b/nx-plugin/src/generators/angular/files/src/app/app-routing.module.ts.template
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
-import { addInitializeModuleGuard } from '@onecx/portal-integration-angular';
+import { addInitializeModuleGuard } from '@onecx/angular-integration-interface';
 
 export const routes: Routes = [
 ];

--- a/nx-plugin/src/generators/create-update/generator.ts
+++ b/nx-plugin/src/generators/create-update/generator.ts
@@ -61,7 +61,8 @@ const PARAMETERS: GeneratorParameter<CreateUpdateGeneratorSchema>[] = [
     default: (values) => {
       return `Create${names(values.featureName).className}Request`;
     },
-    prompt: 'Provide a name for your create request (e.g., CreateBookRequest): ',
+    prompt:
+      'Provide a name for your create request (e.g., CreateBookRequest): ',
     showInSummary: true,
     showRules: [{ showIf: (values) => values.customizeNamingForAPI }],
   },
@@ -84,7 +85,8 @@ const PARAMETERS: GeneratorParameter<CreateUpdateGeneratorSchema>[] = [
     default: (values) => {
       return `Update${names(values.featureName).className}Request`;
     },
-    prompt: 'Provide a name for your update request (e.g., UpdateBookRequest): ',
+    prompt:
+      'Provide a name for your update request (e.g., UpdateBookRequest): ',
     showInSummary: true,
     showRules: [{ showIf: (values) => values.customizeNamingForAPI }],
   },
@@ -128,8 +130,8 @@ export async function createUpdateGenerator(
     spinner.fail('Currently only NgRx projects are supported.');
     throw new Error('Currently only NgRx projects are supported.');
   }
-  
-  let validator = await GeneratorProcessor.runBatch(
+
+  const validator = await GeneratorProcessor.runBatch(
     tree,
     options,
     [new ValidateFeatureModuleStep()],
@@ -137,7 +139,9 @@ export async function createUpdateGenerator(
     true
   );
   if (validator.hasStoppedExecution()) {
-    return () => {};
+    return () => {
+      // Intentionally left blank
+    };
   }
 
   generateFiles(

--- a/nx-plugin/src/generators/delete/generator.ts
+++ b/nx-plugin/src/generators/delete/generator.ts
@@ -79,8 +79,8 @@ export async function deleteGenerator(
     spinner.fail('Currently only NgRx projects are supported.');
     throw new Error('Currently only NgRx projects are supported.');
   }
-  
-  let validator = await GeneratorProcessor.runBatch(
+
+  const validator = await GeneratorProcessor.runBatch(
     tree,
     options,
     [new ValidateFeatureModuleStep()],
@@ -88,7 +88,9 @@ export async function deleteGenerator(
     true
   );
   if (validator.hasStoppedExecution()) {
-    return () => {};
+    return () => {
+      // Intentionally left blank
+    };
   }
 
   const generatorProcessor = new GeneratorProcessor();

--- a/nx-plugin/src/generators/details/generator.ts
+++ b/nx-plugin/src/generators/details/generator.ts
@@ -95,7 +95,7 @@ export async function detailsGenerator(
     throw new Error('Currently only NgRx projects are supported.');
   }
 
-  let validator = await GeneratorProcessor.runBatch(
+  const validator = await GeneratorProcessor.runBatch(
     tree,
     options,
     [new ValidateFeatureModuleStep()],
@@ -103,7 +103,9 @@ export async function detailsGenerator(
     true
   );
   if (validator.hasStoppedExecution()) {
-    return () => {};
+    return () => {
+      // Intentionally left blank
+    };
   }
 
   generateFiles(

--- a/nx-plugin/src/generators/ngrx-page/generator.ts
+++ b/nx-plugin/src/generators/ngrx-page/generator.ts
@@ -59,7 +59,7 @@ export async function componentGenerator(
     throw new Error('Currently only NgRx projects are supported.');
   }
 
-  let validator = await GeneratorProcessor.runBatch(
+  const validator = await GeneratorProcessor.runBatch(
     tree,
     options,
     [new ValidateFeatureModuleStep()],
@@ -67,7 +67,9 @@ export async function componentGenerator(
     true
   );
   if (validator.hasStoppedExecution()) {
-    return () => {};
+    return () => {
+      // Intentionally left blank
+    };
   }
 
   generateFiles(

--- a/nx-plugin/src/generators/search/generator.ts
+++ b/nx-plugin/src/generators/search/generator.ts
@@ -112,7 +112,7 @@ export async function searchGenerator(
     throw new Error('Currently only NgRx projects are supported.');
   }
 
-  let validator = await GeneratorProcessor.runBatch(
+  const validator = await GeneratorProcessor.runBatch(
     tree,
     options,
     [new ValidateFeatureModuleStep()],
@@ -120,7 +120,9 @@ export async function searchGenerator(
     true
   );
   if (validator.hasStoppedExecution()) {
-    return () => {};
+    return () => {
+      // Intentionally left blank
+    };
   }
 
   generateFiles(

--- a/nx-plugin/src/generators/shared/generator.utils.ts
+++ b/nx-plugin/src/generators/shared/generator.utils.ts
@@ -44,7 +44,7 @@ export class GeneratorProcessor<T> {
         step.process(tree, options);
       } catch (error) {
         if (error instanceof GeneratorStepError) {
-          let gsf = error as GeneratorStepError;
+          const gsf = error as GeneratorStepError;
           this.errors.push(gsf);
           if (gsf.errorParameters.stopExecution) {
             break;
@@ -89,7 +89,7 @@ export class GeneratorProcessor<T> {
     ora?: ora.Ora,
     printErrors = false
   ): Promise<GeneratorProcessor<T>> {
-    let genProc = new GeneratorProcessor();
+    const genProc = new GeneratorProcessor();
     steps.forEach((s) => genProc.addStep(s));
     await genProc.run(tree, options, ora, printErrors);
     return genProc;


### PR DESCRIPTION
The addInitializeModuleGuard from portal-integration-angular is deprecated and will be removed in the future
Therefore the import for addInitializeModuleGuard was updated and is now imported from @onecx/angular-integration-interface