### PR TITLE
feat: add react-generator to build and release pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "OneCX Development Team <onecx_dev@1000kit.org>"
   ],
   "scripts": {
-    "build": "nx run nx-plugin:build && nx run create-workspace:build",
+    "build": "nx run nx-plugin:build && nx run create-workspace:build && nx run react-generator:build",
     "build-copy": "npm run build && node copy-build.js",
     "test": "nx run nx-plugin-e2e:e2e",
     "lint": "npx nx affected -t lint",

--- a/react-generator/package.json
+++ b/react-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onecx/react-generator",
-  "version": "8.0.0",
+  "version": "9.0.0-rc.1",
   "license": "Apache-2.0",
   "contributors": [],
   "repository": {

--- a/react-generator/project.json
+++ b/react-generator/project.json
@@ -46,6 +46,16 @@
       "options": {
         "jestConfig": "react-generator/jest.config.ts"
       }
+    },
+    "publish": {
+      "command": "node tools/scripts/publish.mjs react-generator {args.ver} {args.tag}",
+      "dependsOn": ["build"]
+    },
+    "release": {
+      "executor": "@onecx/release:update-build-publish",
+      "options": {
+        "libName": "react-generator"
+      }
     }
   }
 }

--- a/react-generator/src/generators/react/steps/general-openapi.step.ts
+++ b/react-generator/src/generators/react/steps/general-openapi.step.ts
@@ -33,7 +33,7 @@ export class GeneralOpenAPIStep implements GeneratorStep<ReactGeneratorSchema> {
     return 'Adapting OpenAPI';
   }
 
-  isApplicable(_options: ReactGeneratorSchema): boolean {
+  isApplicable(): boolean {
     return true;
   }
 }

--- a/release-script.sh
+++ b/release-script.sh
@@ -13,20 +13,20 @@ then
 fi
 
 # List of publishable packages in this repository
-packages=("nx-plugin" "create-workspace")
+packages=("nx-plugin" "create-workspace" "react-generator")
 
 for package in "${packages[@]}"; do
     packageJsonDataLib=$(cat $package/package.json)
     libPackageVersion=$(echo "$packageJsonDataLib" | jq -r '.version')
-    
+
     # Update @onecx dependencies to use the new version
     packageJsonDataLib=$(echo "$packageJsonDataLib" | sed -E 's/(@onecx[^"]+?": *?")([^"]+)"/\1^'$1'"/')
     echo $packageJsonDataLib > $package/package.json
-    
+
     # Update package version and run release target if version changed
     if [[ $libPackageVersion != $1 ]]
     then
         npx -p replace-json-property rjp $package/package.json version $1
         npx nx run $package:release
-    fi  
+    fi
 done

--- a/release.config.js
+++ b/release.config.js
@@ -62,6 +62,7 @@ module.exports = {
         assets: [
           `nx-plugin/package.json`,
           `create-workspace/package.json`,
+          `react-generator/package.json`,
           `package.json`,
           `CHANGELOG.md`,
         ],


### PR DESCRIPTION
- Add react-generator build step to main build script
- Include react-generator package.json in semantic-release assets
- Add publish and release targets to react-generator project configuration
- Update react-generator version from 8.0.0 to 9.0.0-rc.1
- Add react-generator to release-script.sh packages list
- Remove unused _options parameter from isApplicable method in GeneralOpenAPIStep